### PR TITLE
brew.sh: only hard code HOMEBREW_CURL when HOMEBREW_CURL is empty

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -81,7 +81,7 @@ then
   fi
 fi
 
-HOMEBREW_CURL="/usr/bin/curl"
+[[ -z "HOMEBREW_CURL" ]] && HOMEBREW_CURL="/usr/bin/curl"
 if [[ -n "$HOMEBREW_OSX" ]]
 then
   HOMEBREW_PROCESSOR="$(uname -p)"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

users should be give a chance to choose their version of curl.
